### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 ## IMPORTANT
 
  Asymmetric encryption is done with s/mime set. Be sure when creating  
- a encrypted file by pasting data to a file it's name corrisponds to the 
+ a encrypted file by pasting data to a file it's name corresponds to the 
  encryption method used. 
 
     test.enc for symmetric crypto


### PR DESCRIPTION
@xor-function, I've corrected a typographical error in the documentation of the [minimodem-chat](https://github.com/xor-function/minimodem-chat) project. Specifically, I've changed corrispond to correspond. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.